### PR TITLE
Add `KXButton` and `KXMultiTapButton`

### DIFF
--- a/examples/multi_tap_gesture_recognition.py
+++ b/examples/multi_tap_gesture_recognition.py
@@ -1,61 +1,24 @@
 from kivy.lang import Builder
-from kivy.uix.label import Label
 from kivy.app import App
-
-
-from kivyx.uix.behaviors.tap import KXTapGestureRecognizer, KXMultiTapGestureRecognizer
-from kivyx.uix.behaviors.touchripple import KXTouchRippleBehavior
-
-
-class MultiTapButton(KXTouchRippleBehavior, KXMultiTapGestureRecognizer, Label):
-    def on_multi_tap(self, n_taps, touches):
-        if n_taps == 1:
-            print("single-tapped.")
-        elif n_taps == 2:
-            print("double-tapped.")
-        else:
-            print(f"{n_taps}-tapped.")
-
-
-class SingleTapButton(KXTouchRippleBehavior, KXTapGestureRecognizer, Label):
-    def on_tap(self, touch):
-        print("tapped.")
-
+import kivyx
 
 KV_CODE = '''
-<MultiTapButton, SingleTapButton>:
-    canvas.before:
-        StencilPush:
-        RoundedRectangle:
-            pos: self.pos
-            size: self.size
-        StencilUse:
-        Color:
-            rgba: (.2, .2, .4, 1) if self.disabled else (.4, .2, .8, 1)
-        Rectangle:
-            pos: self.pos
-            size: self.size
-    canvas.after:
-        StencilUnUse:
-        RoundedRectangle:
-            pos: self.pos
-            size: self.size
-        StencilPop:
-
 BoxLayout:
     padding: 40, 40
     spacing: 40
     orientation: 'vertical'
-    MultiTapButton:
+    KXMultiTapButton:
         font_size: 30
         text: "This recognizes multi-tap gestures."
         disabled: not switch.active
         tap_max_count: 7
-    SingleTapButton:
+        on_multi_tap: print(f"{args[1]}-tapped.")
+    KXButton:
         font_size: 30
         text: "This one doesn't."
         disabled: not switch.active
         ripple_color: "#00FF0066"
+        on_tap: print("tapped.")
     Switch:
         id: switch
         active: True

--- a/examples/scrollview_playground.py
+++ b/examples/scrollview_playground.py
@@ -12,27 +12,10 @@ import kivyx
 
 
 KV_CODE = '''
-<MyButton@KXTapGestureRecognizer+KXTouchRippleBehavior+Label>:
+<MyButton@KXButton>:
     font_size: 60
     size_hint_min: 300, 150
     on_tap: print(f"{self.text} tapped.")
-    canvas.before:
-        StencilPush:
-        RoundedRectangle:
-            pos: self.pos
-            size: self.size
-        StencilUse:
-        Color:
-            rgba: .4, .2, .8, 1
-        Rectangle:
-            pos: self.pos
-            size: self.size
-    canvas.after:
-        StencilUnUse:
-        RoundedRectangle:
-            pos: self.pos
-            size: self.size
-        StencilPop:
 
 <Separator@Widget>:
     canvas:
@@ -174,4 +157,4 @@ class SampleApp(App):
 
 
 if __name__ == '__main__':
-    SampleApp(title="Nested ScrollView").run()
+    SampleApp(title="ScrollView playground").run()

--- a/examples/scrollview_scroll_by_distance.py
+++ b/examples/scrollview_scroll_by_distance.py
@@ -6,27 +6,10 @@ from random import randint
 import kivyx
 
 KV_CODE = r'''
-<MyButton@KXTapGestureRecognizer+KXTouchRippleBehavior+Label>:
+<MyButton@KXButton>:
     font_size: 40
     size_hint_min: 300, 100
     on_tap: print(f"{self.text} tapped.")
-    canvas.before:
-        StencilPush:
-        RoundedRectangle:
-            pos: self.pos
-            size: self.size
-        StencilUse:
-        Color:
-            rgba: .4, .2, .8, 1
-        Rectangle:
-            pos: self.pos
-            size: self.size
-    canvas.after:
-        StencilUnUse:
-        RoundedRectangle:
-            pos: self.pos
-            size: self.size
-        StencilPop:
 
 KXScrollView:
     smooth_scroll_end: 50
@@ -57,4 +40,4 @@ class SampleApp(App):
 
 
 if __name__ == '__main__':
-    SampleApp().run()
+    SampleApp(title="scroll by distance").run()

--- a/examples/scrollview_scroll_to_widget.py
+++ b/examples/scrollview_scroll_to_widget.py
@@ -6,27 +6,10 @@ from random import choice
 import kivyx
 
 KV_CODE = r'''
-<MyButton@KXTapGestureRecognizer+KXTouchRippleBehavior+Label>:
+<MyButton@KXButton>:
     font_size: 40
     size_hint_min: 300, 100
     on_tap: print(f"{self.text} tapped.")
-    canvas.before:
-        StencilPush:
-        RoundedRectangle:
-            pos: self.pos
-            size: self.size
-        StencilUse:
-        Color:
-            rgba: .4, .2, .8, 1
-        Rectangle:
-            pos: self.pos
-            size: self.size
-    canvas.after:
-        StencilUnUse:
-        RoundedRectangle:
-            pos: self.pos
-            size: self.size
-        StencilPop:
 
 KXScrollView:
     smooth_scroll_end: 50
@@ -58,4 +41,4 @@ class SampleApp(App):
 
 
 if __name__ == '__main__':
-    SampleApp().run()
+    SampleApp(title="scroll to a widget").run()

--- a/src/kivyx/__init__.py
+++ b/src/kivyx/__init__.py
@@ -15,6 +15,8 @@ def register_components():
     r("KXTouchRippleBehavior", module="kivyx.uix.behaviors.touchripple")
 
     # Widgets
+    r("KXButton", module="kivyx.uix.button")
+    r("KXMultiTapButton", module="kivyx.uix.button")
     r("KXScrollView", module="kivyx.uix.scrollview")
     r("KXSwitch", module="kivyx.uix.switch")
 

--- a/src/kivyx/uix/button.py
+++ b/src/kivyx/uix/button.py
@@ -1,0 +1,41 @@
+__all__ =("KXButton", "KXMultiTapButton", )
+
+from kivy.properties import ColorProperty
+from kivy.lang import Builder
+from kivy.uix.label import Label
+
+
+from kivyx.uix.behaviors.tap import KXTapGestureRecognizer, KXMultiTapGestureRecognizer
+from kivyx.uix.behaviors.touchripple import KXTouchRippleBehavior
+
+
+class KXButton(KXTouchRippleBehavior, KXTapGestureRecognizer, Label):
+    background_color = ColorProperty((.4, .2, .8, 1))
+    background_disabled_color = ColorProperty((.2, .2, .4, 1))
+
+
+class KXMultiTapButton(KXTouchRippleBehavior, KXMultiTapGestureRecognizer, Label):
+    background_color = ColorProperty((.4, .2, .8, 1))
+    background_disabled_color = ColorProperty((.2, .2, .4, 1))
+
+
+Builder.load_string('''
+<KXButton, KXMultiTapButton>:
+    canvas.before:
+        StencilPush:
+        RoundedRectangle:
+            pos: self.pos
+            size: self.size
+        StencilUse:
+        Color:
+            rgba: self.background_disabled_color if self.disabled else self.background_color
+        Rectangle:
+            pos: self.pos
+            size: self.size
+    canvas.after:
+        StencilUnUse:
+        RoundedRectangle:
+            pos: self.pos
+            size: self.size
+        StencilPop:
+''')


### PR DESCRIPTION
examplesのコード量を減らすためにボタンを正式な部品にする。