### PR TITLE
claim_signalが常に鳴るようにする

### DIFF
--- a/src/kivyx/__init__.py
+++ b/src/kivyx/__init__.py
@@ -29,4 +29,8 @@ def setup_claim_signal():
     def put_signal(w, t, Event=asyncgui.StatefulEvent):
         t.ud["kivyx_claim_signal"] = Event()
 
+    def fire_signal(w, t):
+        t.ud["kivyx_claim_signal"].fire()
+
     Window.fbind("on_touch_down", put_signal)
+    Window.fbind("on_touch_up", fire_signal)

--- a/src/kivyx/uix/behaviors/touchripple.py
+++ b/src/kivyx/uix/behaviors/touchripple.py
@@ -3,7 +3,6 @@ __all__ = ("KXTouchRippleBehavior", )
 from typing import Self
 from functools import partial
 import math
-from kivy.core.window import Window
 from kivy.clock import Clock
 from kivy.animation import AnimationTransition
 from kivy.properties import NumericProperty, StringProperty, ColorProperty, BooleanProperty
@@ -42,9 +41,6 @@ class KXTouchRippleBehavior:
 
     ripple_allow_multiple = BooleanProperty(True)
     '''Whether multiple ripples can be shown simultaneously via multi-touch.'''
-
-    ripple_stop_growing_on_claim_signal = BooleanProperty(True)
-    '''Whether the ripple stops growing when ``touch.ud["kivyx_claim_signal"]`` fires..'''
 
     def __init__(self, **kwargs):
         self.__main_task = ak.dummy_task
@@ -103,11 +99,7 @@ class KXTouchRippleBehavior:
             else:
                 final_radius = final_diameter / 2
 
-            coro = ak.event(Window, "on_touch_up", filter=lambda w, t, touch=touch: t is touch)
-            async with ak.run_as_main(
-                ak.wait_any(coro, touch.ud["kivyx_claim_signal"].wait())
-                if self.ripple_stop_growing_on_claim_signal else coro
-            ):
+            async with ak.run_as_main(touch.ud["kivyx_claim_signal"].wait()):
                 await ak.anim_attrs(
                     ellipse,
                     size=(final_diameter, final_diameter, ),

--- a/src/kivyx/uix/scrollview.py
+++ b/src/kivyx/uix/scrollview.py
@@ -96,9 +96,6 @@ class KXScrollView(Widget):
     scroll_distance = NumericProperty(SV.scroll_distance.defaultvalue)
     ''' :attr:`kivy.uix.scrollview.ScrollView.scroll_distance` '''
 
-    scroll_timeout = NumericProperty(0.2)
-    ''' :attr:`kivy.uix.scrollview.ScrollView.scroll_timeout` but in seconds'''
-
     scroll_wheel_distance = NumericProperty(SV.scroll_wheel_distance.defaultvalue)
     ''' :attr:`kivy.uix.scrollview.ScrollView.scroll_wheel_distance` '''
 
@@ -538,11 +535,7 @@ class KXScrollView(Widget):
 
         async with (
             ak.event_freq(Window, "on_touch_move", filter=is_the_same_touch) as on_touch_move,
-            ak.move_on_when(ak.wait_any(
-                claim_signal.wait(),
-                self._on_touch_up(filter=is_the_same_touch),
-                ak.sleep(self.scroll_timeout),
-            )) as cancel_tracker,
+            ak.move_on_when(claim_signal.wait()) as claim_tracker,
         ):
             while True:
                 await on_touch_move()
@@ -565,10 +558,9 @@ class KXScrollView(Widget):
                         break
                     if dx_sum < 0 and self.content_x > self.content_min_x:
                         break
-        if cancel_tracker.finished:
+        if claim_tracker.finished:
             # We withdraw from the touch. The reason can be any of the following:
             # * Someone else took the touch.
-            # * The touch didn't travel far enough within a time limit.
             # * The touch ended before it traveled far enough.
             return
 


### PR DESCRIPTION
そうする事でウィジットの実装を簡略化できる為。

### breaking changes

- Remove `KXTouchRippleBehavir.ripple_stop_growing_on_claim_signal`
- Remove `KXScrollView.scroll_timeout`